### PR TITLE
LIBASPACE-253. Modified view to strip HTML tags from values

### DIFF
--- a/public/views/containers/show.html.erb
+++ b/public/views/containers/show.html.erb
@@ -30,11 +30,11 @@ mapper = AeonRecordMapper.mapper_for(@result)
 					<% if name.casecmp('requests').zero? %>
 						<% value.each do |request| %>
 							<% request.each do |request_param, request_value| %>
-								<input type='hidden' name='<%= request_param %>' value='<%= request_value %>' />
+								<input type='hidden' name='<%= request_param %>' value='<%= strip_tags(request_value.to_s) %>' />
 							<% end %>
 						<% end %>
 					<% else %>
-						<input type='hidden' name='<%= name %>' value='<%= value %>' />
+						<input type='hidden' name='<%= name %>' value='<%= strip_tags(value.to_s) %>' />
 					<% end %>
 				<% end %>
 


### PR DESCRIPTION
Modified "show.html.erb" to strip HTML tags from the values provided
as form inputs. This is needed as Aeon displays an error if the
form inputs contain an HTML tag.

This change is similar to a change made in pull 29 of
the "AtlasSystems/ArchivesSpace-Aeon-Fulfillment-Plugin".

https://issues.umd.edu/browse/LIBASPACE-253