### PR TITLE
LIBASPACE-397. Update umd_aeon_fulfillment for v4.1.1

### DIFF
--- a/docs/Customizations.md
+++ b/docs/Customizations.md
@@ -58,67 +58,67 @@ The steps are assume that the "William L. Amoss papers" collection is available,
 either by running the steps against either an actual server, or in a local
 development environment set up with sample data according to the instructions
 in the "[docs/DevelopmentSetup.md][dev_setup]" document in the
-"[umd-lib/aspace-custom][aspace-custom] GitHub repository.
+"[umd-lib/aspace-custom][aspace-custom]" GitHub repository.
 
 1) In a web browser, go to the ArchivesSpace public interface home page.
 
 2) On the public interface home page, enter `William L. Amoss papers` into the
-   “Enter your search terms” textbox, and left-click the “Search” button. A
+   "Enter your search terms" textbox, and left-click the "Search" button. A
    search results page will be displayed.
 
-3) On the search results page, left-click the “William L. Amoss papers”
-   collection result. The “William L. Amoss papers” page will be displayed.
+3) On the search results page, left-click the "William L. Amoss papers"
+   collection result. The "William L. Amoss papers" page will be displayed.
 
-4) On the “William L. Amoss papers” page, verify that a blue box is displayed
+4) On the "William L. Amoss papers" page, verify that a blue box is displayed
    just below the navigation bar, with the text:
 
    > Use the right side menu to identify relevant boxes and place requests.
 
-   In the right sidebar, left-click the “Subject Files, 1895-1927” entry. The
-   “Subject Files, 1895-1927” page will be displayed.
+   In the right sidebar, left-click the "Subject Files, 1895-1927" entry. The
+   "Subject Files, 1895-1927" page will be displayed.
 
-5) On the “Subject Files, 1895-1927” page, verify that:
+5) On the "Subject Files, 1895-1927" page, verify that:
 
    * a blue box is displayed just below the navigation bar, with the text:
 
      > Use the right side menu to identify relevant boxes and place requests.
 
-   * a “Request” button is *not* shown next to the “Citation” button
+   * a "Request" button is *not* shown next to the "Citation" button
 
-   In the right sidebar, left-click the “Alabama, 1916” entry. The
-   “Alabama, 1916” page will be displayed.
+   In the right sidebar, left-click the "Alabama, 1916" entry. The
+   "Alabama, 1916" page will be displayed.
 
-6) On the “Alabama, 1916” page, verify that:
+6) On the "Alabama, 1916" page, verify that:
 
     * a blue box is displayed just below the navigation bar, with the text:
 
       > Use the right side menu to identify relevant boxes and place requests.
 
-    * A “Request Box 1” button is displayed to the right of the “Citation”
+    * A "Request Box 1" button is displayed to the right of the "Citation"
       button.
 
-   Left-click the “Request Box 1” button. The “Box 1” page will be displayed.
+   Left-click the "Request Box 1" button. The "Box 1" page will be displayed.
 
-7) On the “Box 1” page, verify that in the right sidebar is a blue box with the
+7) On the "Box 1" page, verify that in the right sidebar is a blue box with the
   text:
 
     > Click button below to request this box. You will be asked to
     > register/sign in to your Special Collections Research Account to complete
     > your request.
 
-   and below the text is a “Request Box 1” button.
+   and below the text is a "Request Box 1" button.
 
-   Left-click the “Request Box 1” button. A separate browser tab will open with
+   Left-click the "Request Box 1" button. A separate browser tab will open with
    the Aeon login page.
 
-8) Log in to Aeon. After logging in, the “Special Collections Account” page will
-   be displayed with a “Saved Request” of
-   “William L. Amoss papers Subject Files, 1895-1927”.
+8) Log in to Aeon. After logging in, the "Special Collections Account" page will
+   be displayed with a "Saved Request" of
+   "William L. Amoss papers Subject Files, 1895-1927".
 
-   Left-click the “Edit” button in the “Saved Request”. The “Edit Request” page
+   Left-click the "Edit" button in the "Saved Request". The "Edit Request" page
    will be displayed.
 
-9) On the “Edit Request” page, verify the contents of the following fields:
+9) On the "Edit Request" page, verify the contents of the following fields:
 
     | Field        | Value |
     | ------------ | ----- |
@@ -139,22 +139,22 @@ in the "[docs/DevelopmentSetup.md][dev_setup]" document in the
 
    ----
 
-   Left-click the “Cancel - Return to Main Menu” button. The
-   “Special Collections Account” page will be displayed.
+   Left-click the "Cancel - Return to Main Menu" button. The
+   "Special Collections Account" page will be displayed.
 
-10) On the “Special Collections Account” page, in the
-    “William L. Amoss papers Subject Files, 1895-1927” entry, left-click
-    “Actions | Cancel Request” to cancel the request without submitting it.
+10) On the "Special Collections Account" page, in the
+    "William L. Amoss papers Subject Files, 1895-1927" entry, left-click
+    "Actions | Cancel Request" to cancel the request without submitting it.
 
 11) (Optional) In ArchivesSpace, type `William L. Amoss papers` into the
-    “Search” box in the navigation bar, and then select the
-    “William L. Amoss papers” result. On the “William L. Amoss papers” page,
-    select “Publications | African-American Education and Labor -- Atlanta University, 1898”
+    "Search" box in the navigation bar, and then select the
+    "William L. Amoss papers" result. On the "William L. Amoss papers" page,
+    select "Publications | African-American Education and Labor -- Atlanta University, 1898"
     entry in the right sidebar.
 
-    On the “African-American Education and Labor -- Atlanta University, 1898”
-    page, verify that a “Request Box 2” button is shown to the right of the
-    “Citation” button.
+    On the "African-American Education and Labor -- Atlanta University, 1898"
+    page, verify that a "Request Box 2" button is shown to the right of the
+    "Citation" button.
 
 ----
 [aeon_fulfillment]: https://github.com/AtlasSystems/ArchivesSpace-Aeon-Fulfillment-Plugin

--- a/public/views/aeon/_aeon_request_action.html.erb
+++ b/public/views/aeon/_aeon_request_action.html.erb
@@ -1,21 +1,36 @@
-<% 
-    mapper = AeonRecordMapper.mapper_for(record)
+<%
+Rails.logger.info("Aeon Fulfillment Plugin") { "Initializing Plugin..." }
+
+mapper = AeonRecordMapper.mapper_for(record)
 %>
 
-<% unless mapper.hide_button? %>
+<% if mapper.configured? %>
 
-  <% if mapper.show_action? && tc = mapper.top_containers.first %>
-    <a id='aeon-request' class='btn btn-default' href="<%= app_prefix(tc["ref"]) %>">
-      <i class="<%= t('plugins.aeon_fulfillment.request_button_icon') %>"></i><br/>
-      <%= t('plugins.aeon_fulfillment.request_button_label',
-            label: "#{ tc['_resolved']['type']? tc['_resolved']['type'].humanize : 'Container'} #{tc['_resolved']['indicator']}") %>
-    </a>
-  <% else %>
+  <%= javascript_include_tag "#{@base_url}/assets/js/aeon_request_action.js" %>
 
+  <%# UMD Customization %>
+  <% if mapper.hide_button? %>
     <button class="btn btn-default page_action request" disabled="true">
       <i class="fa fa-external-link fa-3x"></i><br/><%= t('plugins.aeon_fulfillment.request_not_allowed') %>
     </button>
+  <% else %>
+
+    <% if tc = mapper.top_containers.first %>
+      <a id='aeon-request' class='btn btn-default' href="<%= app_prefix(tc["ref"]) %>">
+        <i class="<%= t('plugins.aeon_fulfillment.request_button_icon') %>"></i><br/>
+        <%= t('plugins.aeon_fulfillment.request_button_label',
+              label: "#{ tc['_resolved']['type']? tc['_resolved']['type'].humanize : 'Container'} #{tc['_resolved']['indicator']}") %>
+      </a>
+    <% end %>
 
   <% end %>
-
+  <%# End UMD Customization %>
+<% else %>
+<%
+  Rails.logger.info("Aeon Fulfillment Plugin") { "Plugin not configured." }
+%>
 <% end %>
+
+<%
+  Rails.logger.info("Aeon Fulfillment Plugin") { "Finished initializing plugin." }
+%>

--- a/public/views/aeon/_aeon_request_action.html.erb
+++ b/public/views/aeon/_aeon_request_action.html.erb
@@ -5,7 +5,7 @@
 <% unless mapper.hide_button? %>
 
   <% if mapper.show_action? && tc = mapper.top_containers.first %>
-    <a id='aeon-request' class='btn btn-default' href="<%= app_prefix(tc["ref"]) %>">
+    <a id='aeon-request' class='btn btn-default page_action' href="<%= app_prefix(tc["ref"]) %>">
       <i class="<%= t('plugins.aeon_fulfillment.request_button_icon') %>"></i><br/>
       <%= t('plugins.aeon_fulfillment.request_button_label',
             label: "#{ tc['_resolved']['type']? tc['_resolved']['type'].humanize : 'Container'} #{tc['_resolved']['indicator']}") %>

--- a/public/views/aeon/_aeon_request_action.html.erb
+++ b/public/views/aeon/_aeon_request_action.html.erb
@@ -1,36 +1,21 @@
 <%
-Rails.logger.info("Aeon Fulfillment Plugin") { "Initializing Plugin..." }
-
-mapper = AeonRecordMapper.mapper_for(record)
+    mapper = AeonRecordMapper.mapper_for(record)
 %>
 
-<% if mapper.configured? %>
+<% unless mapper.hide_button? %>
 
-  <%= javascript_include_tag "#{@base_url}/assets/js/aeon_request_action.js" %>
+  <% if mapper.show_action? && tc = mapper.top_containers.first %>
+    <a id='aeon-request' class='btn btn-default' href="<%= app_prefix(tc["ref"]) %>">
+      <i class="<%= t('plugins.aeon_fulfillment.request_button_icon') %>"></i><br/>
+      <%= t('plugins.aeon_fulfillment.request_button_label',
+            label: "#{ tc['_resolved']['type']? tc['_resolved']['type'].humanize : 'Container'} #{tc['_resolved']['indicator']}") %>
+    </a>
+  <% else %>
 
-  <%# UMD Customization %>
-  <% if mapper.hide_button? %>
     <button class="btn btn-default page_action request" disabled="true">
       <i class="fa fa-external-link fa-3x"></i><br/><%= t('plugins.aeon_fulfillment.request_not_allowed') %>
     </button>
-  <% else %>
-
-    <% if tc = mapper.top_containers.first %>
-      <a id='aeon-request' class='btn btn-default' href="<%= app_prefix(tc["ref"]) %>">
-        <i class="<%= t('plugins.aeon_fulfillment.request_button_icon') %>"></i><br/>
-        <%= t('plugins.aeon_fulfillment.request_button_label',
-              label: "#{ tc['_resolved']['type']? tc['_resolved']['type'].humanize : 'Container'} #{tc['_resolved']['indicator']}") %>
-      </a>
-    <% end %>
 
   <% end %>
-  <%# End UMD Customization %>
-<% else %>
-<%
-  Rails.logger.info("Aeon Fulfillment Plugin") { "Plugin not configured." }
-%>
-<% end %>
 
-<%
-  Rails.logger.info("Aeon Fulfillment Plugin") { "Finished initializing plugin." }
-%>
+<% end %>

--- a/public/views/containers/show.html.erb
+++ b/public/views/containers/show.html.erb
@@ -1,20 +1,28 @@
+<%# UMD Customization %>
 <%
 mapper = AeonRecordMapper.mapper_for(@result)
 %>
-
+<%# End UMD Customization %>
 <div id="main-content" class="containers">
-<div class="row">
-  <div class="information col-sm-7">
+<div class="d-flex">
+  <div class="information flex-grow-1">
     <%= render partial: 'shared/idbadge', locals: {:result => @result, :props => { :full => true} } %>
   </div>
-  <div class="page_actions col-sm-5 right">
+  <div class="page_actions">
     <%= render partial: 'shared/page_actions', locals: {:record => @result, :title => @result.display_string, :url => request.fullpath } %>
   </div>
 </div>
 <div class="row">
   <div class="col-sm-9">
+
+    <div class="staff-hidden d-none">
+      <% if @result['json']['restricted'] %>
+        <p><h4 class='restricted'><%= I18n.t('top_container.restricted') %></h4></p>
+      <% end %>
+    </div>
+
     <% unless @results.blank? || @results['total_hits'] == 0 %>
-      <h3><%= t('contains', {:count => @results['total_hits'], :type => @results['total_hits'] == 1? t('coll_obj._singular') : t('coll_obj._plural')}) %>:</h3>
+      <h2><%= t('contains', :count => @results['total_hits'], :type => @results['total_hits'] == 1? t('search_results.result') : t('search_results.results')) %>:</h2>
       <% @results.records.each do |result| %>
         <%= render partial: 'shared/result', locals: {:result => result, :props => {:full => false}} %>
       <% end %>
@@ -22,6 +30,7 @@ mapper = AeonRecordMapper.mapper_for(@result)
     <% end %>
   </div>
 
+  <%# UMD Customization %>
   <div id="sidebar" class="col-sm-3 sidebar sidebar-container">
   	<% if mapper.show_action?  %>
 		  <div class="request_instructions"><%= t('plugins.aeon_fulfillment.request_instructions') %></div>
@@ -43,9 +52,10 @@ mapper = AeonRecordMapper.mapper_for(@result)
 				</button>
     	<% end %>
     <% end %>
-		<% unless @results.blank? || @results['total_hits'] == 0 %>
+    <% unless @results.blank? || @results['total_hits'] == 0 || @facets.blank? %>
       <%= render partial: 'shared/facets' %>
     <% end %>
   </div>
+  <%# End UMD Customization %>
 </div>
 </div>


### PR DESCRIPTION
Initial attempts to get the “umd_aeon_fulfillment” plugin to work with the latest tagged ArchivesSpace-Aeon-Fulfillment-Plugin ([20250617](https://github.com/AtlasSystems/ArchivesSpace-Aeon-Fulfillment-Plugin/releases/tag/20250617)) were unsuccessful. After reverting back to using the [20180726](https://github.com/AtlasSystems/ArchivesSpace-Aeon-Fulfillment-Plugin/releases/tag/20180726) version of the Atlas Aeon Fulfillment plugin (that the “umd_aeon_fulfillment” plugin was originally designed to work with), it was found that the plugin would work with ArchivesSpace 4.1.1 with only changes to the HTML template ERB files. Since there does not appear to be any significant benefit to using the “latest” ArchivesSpace-Aeon-Fulfillment-Plugin, continuing to use the older version is reasonable.

https://umd-dit.atlassian.net/browse/LIBASPACE-397