### PR TITLE
LIBASPACE-416. Fix Aeon login for non-Shibboleth users

### DIFF
--- a/docs/Customizations.md
+++ b/docs/Customizations.md
@@ -49,6 +49,12 @@ The "umd_aeon_fulfillment" plugin customizes the
   * Volume/Box - The {Box} {Box Series} and {Barcode}
   * Restrictions - whether or not the item is restricted
 
+* An upstream fix (from ArchivesSpace-Aeon-Fulfillment-Plugin commit
+  [8e4ea5f](https://github.com/AtlasSystems/ArchivesSpace-Aeon-Fulfillment-Plugin/commit/8e4ea5f936241cbe076063e676289b4cf31e4a39))
+  has been added to the "public/views/containers/show.html.erb" file to fix a
+  login loop when logging in to Aeon using a "Guest Researcher" (non-Shibboleth)
+  login.
+
 ## Verification Steps
 
 The following steps are intended to verify that the umd_aeon_fulfillment_plugin
@@ -111,9 +117,10 @@ in the "[docs/DevelopmentSetup.md][dev_setup]" document in the
    Left-click the "Request Box 1" button. A separate browser tab will open with
    the Aeon login page.
 
-8) Log in to Aeon. After logging in, the "Special Collections Account" page will
-   be displayed with a "Saved Request" of
-   "William L. Amoss papers Subject Files, 1895-1927".
+8) Log in to Aeon, using the "Login or Register" button in the
+   "UMD Students, Faculty and Staff" panel and your CAS id. After logging in,
+   the "Special Collections Account" page will be displayed with a
+   "Saved Request" of "William L. Amoss papers Subject Files, 1895-1927".
 
    Left-click the "Edit" button in the "Saved Request". The "Edit Request" page
    will be displayed.
@@ -146,7 +153,12 @@ in the "[docs/DevelopmentSetup.md][dev_setup]" document in the
     "William L. Amoss papers Subject Files, 1895-1927" entry, left-click
     "Actions | Cancel Request" to cancel the request without submitting it.
 
-11) (Optional) In ArchivesSpace, type `William L. Amoss papers` into the
+11) (Optional) Using a "guest researcher" Aeon login (creating one, if
+    necessary), repeat steps 8-10, using the "Login or Register" button in the
+    "Guest Researcher" panel, and verifying that an Aeon request is successfully
+    created.
+
+12) (Optional) In ArchivesSpace, type `William L. Amoss papers` into the
     "Search" box in the navigation bar, and then select the
     "William L. Amoss papers" result. On the "William L. Amoss papers" page,
     select "Publications | African-American Education and Labor -- Atlanta University, 1898"

--- a/public/views/containers/show.html.erb
+++ b/public/views/containers/show.html.erb
@@ -34,7 +34,16 @@ mapper = AeonRecordMapper.mapper_for(@result)
   <div id="sidebar" class="col-sm-3 sidebar sidebar-container">
   	<% if mapper.show_action?  %>
 		  <div class="request_instructions"><%= t('plugins.aeon_fulfillment.request_instructions') %></div>
-			<%= form_tag "#{mapper.repo_settings[:aeon_web_url]}?action=11&type=200", :id => 'aeon_request_sub', :target => (mapper.repo_settings.fetch(:request_in_new_tab, false) ? 'aeon_request' : '_self') do |f| %>
+      <%#
+        Following incorporates changes from https://github.com/AtlasSystems/ArchivesSpace-Aeon-Fulfillment-Plugin/commit/8e4ea5f936241cbe076063e676289b4cf31e4a39
+        to fix a login loop. As the "top_container_mode" property does not exist
+        in the older aeon_fulfillment plugin version on which this plugin is
+        based, simply hard-coded the appropriate values when
+        "top_container_mode=false".
+      %>
+      <%= form_tag "#{mapper.repo_settings[:aeon_web_url]}", :id => 'aeon_request_sub', :target => (mapper.repo_settings.fetch(:request_in_new_tab, false) ? 'aeon_request' : '_self') do |f| %>
+        <input type='hidden' name='AeonForm' value='ExternalRequest' />
+      <%# End change for https://github.com/AtlasSystems/ArchivesSpace-Aeon-Fulfillment-Plugin/commit/8e4ea5f936241cbe076063e676289b4cf31e4a39 %>
 				<% mapper.map.each do |name, value| %>
 					<% if name.casecmp('requests').zero? %>
 						<% value.each do |request| %>


### PR DESCRIPTION
Incorporated change from ArchivesSpace-Aeon-Fulfillment-Plugin commit [8e4ea5f](https://github.com/AtlasSystems/ArchivesSpace-Aeon-Fulfillment-Plugin/commit/8e4ea5f936241cbe076063e676289b4cf31e4a39) to fix "looping" on Aeon login page for non-Shibboleth logins.

Note: Removed "top_container_mode" check from the upstream commit, because we are using an earlier version of the
ArchivesSpace-Aeon-Fulfillment-Plugin that
does not use that parameter. Hard-coded changes are equivalent to "top_container_mode=false"

Updated "Customizations.md" to call out the update, and added optional verification steps to verify the functionality.

https://umd-dit.atlassian.net/browse/LIBASPACE-416